### PR TITLE
Fix/use settle index

### DIFF
--- a/db.go
+++ b/db.go
@@ -42,7 +42,8 @@ func OpenDB(config *Config) (db *gorm.DB, err error) {
 
 type Invoice struct {
 	gorm.Model
-	AddIndex uint64
+	AddIndex    uint64
+	SettleIndex uint64
 }
 
 type Payment struct {

--- a/service.go
+++ b/service.go
@@ -100,7 +100,10 @@ func (svc *Service) lookupLastInvoiceIndex(ctx context.Context) (index uint64, e
 	if tx.Error != nil && tx.Error != gorm.ErrRecordNotFound {
 		return 0, tx.Error
 	}
-	return inv.AddIndex, nil
+	//settle index is monotonically increasing for each settled invoice
+	//(https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-invoices)
+	//so the last payment in the database should have the highest settle invoice
+	return inv.SettleIndex, nil
 }
 
 func (svc *Service) lookupLastPaymentTimestamp(ctx context.Context) (lastPaymentCreationTimeUnix int64, err error) {
@@ -248,18 +251,18 @@ func (svc *Service) startPaymentSubscription(ctx context.Context) error {
 }
 
 func (svc *Service) startInvoiceSubscription(ctx context.Context) error {
-	addIndex, err := svc.lookupLastInvoiceIndex(ctx)
+	settleIndex, err := svc.lookupLastInvoiceIndex(ctx)
 	if err != nil {
 		return err
 	}
 	invoiceSub, err := svc.lnd.SubscribeInvoices(ctx, &lnrpc.InvoiceSubscription{
-		AddIndex: addIndex,
+		SettleIndex: settleIndex,
 	})
 	if err != nil {
 		sentry.CaptureException(err)
 		return err
 	}
-	logrus.Infof("Starting invoice subscription from index %d", addIndex)
+	logrus.Infof("Starting invoice subscription from index %d", settleIndex)
 	for {
 		select {
 		case <-ctx.Done():

--- a/service.go
+++ b/service.go
@@ -139,7 +139,8 @@ func (svc *Service) lookupLastPaymentTimestamp(ctx context.Context) (lastPayment
 
 func (svc *Service) AddLastPublishedInvoice(ctx context.Context, invoice *lnrpc.Invoice) error {
 	return svc.db.WithContext(ctx).Create(&Invoice{
-		AddIndex: invoice.AddIndex,
+		AddIndex:    invoice.AddIndex,
+		SettleIndex: invoice.SettleIndex,
 	}).Error
 }
 


### PR DESCRIPTION
This is the 2nd part of #11 
To be deployed after the settle_index database field has been filled by deploying #13 .
After that we can run a reconciliation script to fetch any possible missing payments.

I have reproduced the issue on testnet:

- create 2 invoices, pay the 2nd
- stop the publisher
- pay the 1st invoice
- start the publisher again
- confirm that the 1st invoice is present in LND but still marked as open in LNDhub.

