### PR TITLE
add channels for async confirmation waiting

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -116,11 +116,6 @@ func TestPaymentPublish(t *testing.T) {
 	assert.False(t, timedOut)
 	assert.Equal(t, lnrpc.Payment_SUCCEEDED, receivedPayment.Status)
 
-	//mock the same payment again
-	mlnd.mockPayment(lnrpc.Payment_SUCCEEDED, index, "hash2")
-	timedOut, receivedPayment = timeoutOrNewPaymentFromRabbit(t, m)
-	//should not get published
-	assert.True(t, timedOut)
 	// mock an in-flight payment
 	index += 1
 	mlnd.mockPayment(lnrpc.Payment_IN_FLIGHT, index, "hash3")

--- a/integration_test.go
+++ b/integration_test.go
@@ -70,9 +70,7 @@ func TestInvoicePublish(t *testing.T) {
 	}
 	svc, mlnd, m := createTestService(t, cfg, LNDInvoiceExchange, LNDInvoiceRoutingKey)
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		svc.startInvoiceSubscription(ctx)
-	}()
+	svc.StartRoutines(ctx)
 	// - mock incoming invoice
 	// the new invoice that will be saved will have addIndex + 1
 	err := mlnd.mockPaidInvoice(100, "integration test")

--- a/main.go
+++ b/main.go
@@ -59,6 +59,8 @@ func main() {
 		sentry.CaptureException(err)
 		logrus.Fatal(err)
 	}
+	//create buffered channels to handle publisher confirms
+	//so we don't block publishing if there is a peak in traffic
 	cci := make(chan InvoiceConfirmation, 100)
 	ccp := make(chan PaymentConfirmation, 100)
 	svc := &Service{

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"time"
 
@@ -80,10 +81,10 @@ func main() {
 	wg.Add(1)
 	go func() {
 		err = svc.startInvoiceSubscription(ctx)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
 			logrus.Fatal(err)
 		}
-		logrus.Info("invoice sub done")
+		logrus.Info("invoice subscription loop done")
 		wg.Done()
 	}()
 	wg.Add(1)
@@ -91,19 +92,19 @@ func main() {
 		//listen to confirm channel from invoices
 		//and update apropriately in the database
 		err = svc.StartInvoiceConfirmationLoop(ctx)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
 			logrus.Fatal(err)
 		}
-		logrus.Info("invoice conf done")
+		logrus.Info("invoice confirmation loop done")
 		wg.Done()
 	}()
 	wg.Add(1)
 	go func() {
 		err = svc.startPaymentSubscription(ctx)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
 			logrus.Fatal(err)
 		}
-		logrus.Info("payment sub done")
+		logrus.Info("payment subscription loop done")
 		wg.Done()
 	}()
 	wg.Add(1)
@@ -111,11 +112,11 @@ func main() {
 		//listen to confirm channel from payments
 		//and update apropriately in the database
 		err = svc.StartPaymentConfirmationLoop(ctx)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
 			logrus.Fatal(err)
 		}
 
-		logrus.Info("payment confirmation done")
+		logrus.Info("payment confirmation loop done")
 		wg.Done()
 	}()
 	<-ctx.Done()
@@ -127,4 +128,5 @@ func main() {
 	}()
 	//wait for goroutines to finish
 	wg.Wait()
+	logrus.Info("Exited gracefully. Goodbye.")
 }

--- a/service.go
+++ b/service.go
@@ -367,7 +367,7 @@ func (svc *Service) StartInvoiceConfirmationLoop(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return context.Canceled
 		case ic := <-svc.confirmChannelInvoices:
 			logrus.Infof("invoice chan length %d", len(svc.confirmChannelInvoices))
 			ok, err := ic.confirmation.WaitContext(ctx)
@@ -386,7 +386,7 @@ func (svc *Service) StartPaymentConfirmationLoop(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return context.Canceled
 		case ic := <-svc.confirmChannelPayments:
 			logrus.Infof("payment chan length %d", len(svc.confirmChannelPayments))
 			ok, err := ic.confirmation.WaitContext(ctx)

--- a/service.go
+++ b/service.go
@@ -363,7 +363,7 @@ func (svc *Service) StartInvoiceConfirmationLoop(ctx context.Context) error {
 			}
 			logrus.WithFields(
 				logrus.Fields{
-					"invoice_chan_lenght": len(svc.confirmChannelInvoices),
+					"invoice_chan_length": len(svc.confirmChannelInvoices),
 					"payment_hash":        hex.EncodeToString(ic.invoice.RHash),
 				}).Info("handled invoice confirmation")
 		}

--- a/service.go
+++ b/service.go
@@ -405,7 +405,7 @@ func (svc *Service) StartPaymentConfirmationLoop(ctx context.Context) error {
 			logrus.WithFields(
 				logrus.Fields{
 					"payment_chan_length": len(svc.confirmChannelPayments),
-					"payment_hash":        hex.EncodeToString([]byte(ic.payment.PaymentHash)),
+					"payment_hash":        ic.payment.PaymentHash,
 				}).Info("handled payment confirmation")
 		}
 	}

--- a/start_routines.go
+++ b/start_routines.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// starts the 4 routines:
+//   - subscribe invoices
+//   - handle invoice confirmations
+//   - subscribe payments
+//   - handle payment confirmations
+func (svc *Service) StartRoutines(ctx context.Context) (wg *sync.WaitGroup) {
+	wg = &sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		err := svc.startInvoiceSubscription(ctx)
+		if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
+			logrus.Fatal(err)
+		}
+		logrus.Info("invoice subscription loop done")
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		//listen to confirm channel from invoices
+		//and update apropriately in the database
+		err := svc.StartInvoiceConfirmationLoop(ctx)
+		if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
+			logrus.Fatal(err)
+		}
+		logrus.Info("invoice confirmation loop done")
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		err := svc.startPaymentSubscription(ctx)
+		if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
+			logrus.Fatal(err)
+		}
+		logrus.Info("payment subscription loop done")
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		//listen to confirm channel from payments
+		//and update apropriately in the database
+		err := svc.StartPaymentConfirmationLoop(ctx)
+		if err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
+			logrus.Fatal(err)
+		}
+
+		logrus.Info("payment confirmation loop done")
+		wg.Done()
+	}()
+	return wg
+}


### PR DESCRIPTION
This PR aims to 

- handle publisher confirms asynchronously because otherwise they might take too long.
- simplify the code by removing some hard-to-reason about constructions (eg. gorm.TX )

It creates 2 extra goroutines that each consume a golang channel. The payload on this channel is the lnrpc payload + the rabbitmq confirmation. They wait for the confirmation and then update the corresponding record in the database:

- invoices get inserted.
- payments get updated.

It also implements graceful shutdown of the goroutines.